### PR TITLE
suppress warning for unescaped { in regex

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 See http://github.com/miyagawa/cpanminus/ for the latest development.
 
+1.1006  2016-02-19T07:39:18
+   - suppress warning for unescaped {
+
 1.1005  2011-06-18T18:04:24
    - follow symlinks when traversing @INC
 

--- a/cpanm
+++ b/cpanm
@@ -1520,7 +1520,7 @@ $fatpacked{"App/cpanminus/script.pm"} = <<'APP_CPANMINUS_SCRIPT';
           $self->chat("Finding PREREQ from Makefile ...\n");
           open my $mf, "Makefile";
           while (<$mf>) {
-              if (/^\#\s+PREREQ_PM => {\s*(.*?)\s*}/) {
+              if (/^\#\s+PREREQ_PM => \{\s*(.*?)\s*\}/) {
                   my @all;
                   my @pairs = split ', ', $1;
                   for (@pairs) {

--- a/lib/App/cpanminus.pm
+++ b/lib/App/cpanminus.pm
@@ -1,5 +1,5 @@
 package App::cpanminus;
-our $VERSION = "1.1005";
+our $VERSION = "1.1006";
 
 =head1 NAME
 

--- a/lib/App/cpanminus/script.pm
+++ b/lib/App/cpanminus/script.pm
@@ -1196,7 +1196,7 @@ sub find_prereqs {
         $self->chat("Finding PREREQ from Makefile ...\n");
         open my $mf, "Makefile";
         while (<$mf>) {
-            if (/^\#\s+PREREQ_PM => {\s*(.*?)\s*}/) {
+            if (/^\#\s+PREREQ_PM => \{\s*(.*?)\s*\}/) {
                 my @all;
                 my @pairs = split ', ', $1;
                 for (@pairs) {


### PR DESCRIPTION
Cosmetic but annoying.

```
Debug: Prefetching cpan resources for package
Debug: Executing '/usr/local/bin/cpanm --list'
Warning: Could not match Unescaped left brace in regex is deprecated, passed through in regex; marked by <-- HERE in m/^\#\s+PREREQ_PM => { <-- HERE \s*(.*?)\s*}/ at /loader/0x1c719c8/App/cpanminus/script.pm line 1199.
```

It looks like we don't run `perl Makefile.PL` ourselves -- it results in a much bigger diff, and so I dropped the changes in manually. Let me know if I should do that in preference.
